### PR TITLE
Add Dockerfile for image based on local source copy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,25 @@ docker exec -it flowdec /bin/bash # Connect
 
 The Flowdec dockerfile extends the [TensorFlow DockerHub Images](https://hub.docker.com/r/tensorflow/tensorflow/) so its usage is similar where running it in the foreground automatically starts jupyter notebook and prints a link to connect to it via a browser on the host system.
 
+The previous two images are built from the current master branch
+of github.com/hammerlab/flowdec.git.  To build an image using
+your local copy of the source, you can use this command:
+
+```bash
+docker build --no-cache -t flowdec -f docker/Dockerfile.devel .
+```
+
+You may want to combine this with a bind mount of your local source tree into
+the running container.  This setup will let you make edits to the source and
+have them immediately take effect in the running container.
+
+```bash
+LOCAL_SRC=$(pwd)
+DEST_SRC=/repos/flowdec
+
+docker run -ti -p 8888:8888 -v ${LOCAL_SRC}:${DEST_SRC} flowdec
+```
+
 ## Validation
 
 By in large, the purpose of this project is to attain near equivalence with a subset of the functionality provided by both [DeconvolutionLab2](http://bigwww.epfl.ch/deconvolution/deconvolutionlab2/) and [PSFGenerator](http://bigwww.epfl.ch/algorithms/psfgenerator/) via much faster implementations.

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -1,0 +1,29 @@
+FROM tensorflow/tensorflow:1.6.0-py3
+
+ENV TF_GPU false
+
+RUN apt-get update && apt-get install -y --no-install-recommends git vim
+
+RUN mkdir -p /repos/flowdec
+
+#
+# This will build an image based on the current state of your local source.
+# With pip install -e, the installed Python package will point back
+# at the source directory, /repos/flowdec.  Any changes made in that
+# tree will be used without having to install again.
+#
+# This is most helpful when used in combination with a bind mount of
+# your local source tree on top of this location, so you can make edits
+# as usual, and not within the running container.
+#
+# Note that if you change the structure of the project in any way,
+# like adding/removing/renaming/moving files, you will either need to
+# rebuild the image, or run the "pip install" command again inside the
+# container.
+#
+COPY . /repos/flowdec/.
+RUN cd /repos/flowdec/python && pip install -e .
+
+RUN mkdir /notebooks/flowdec
+
+COPY python/examples /notebooks/flowdec


### PR DESCRIPTION
The existing Dockerfiles build an image based on the latest master
branch of flowdec.  This variation lets you build a docker image based
on the current local copy of the source.