### PR TITLE
Drop automatic tensorflow installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,19 @@ python examples/scripts/deconvolution.py \
 The project can be installed, ideally in a python 3.6 environment (though it should work in 3.5 too), by running:
 
 ```bash
-export TF_GPU=true # Set to false for cpu-only environments
-pip install flowdec
+pip install flowdec[tf_gpu]
 ```
+
+The previous command will install `flowdec`, but also ensure that `tensorflow`
+is installed with GPU support.  For test purposes, you may have the non-GPU
+enabled version of `tensorflow` installed by running:
+
+```bash
+pip install flowdec[tf]
+```
+
+If neither `[tf]` or `[tf_gpu]` are specified, tensorflow installation is left
+as an externally managed prerequisite.
 
 Alternatively, the project could be installed from source by doing the following:
 
@@ -140,7 +150,6 @@ Note that this project requires either the ```tensorflow``` or ```tensorflow-gpu
 ```TF_GPU``` environment variable is used in the installation script to determine which dependency is required.
   If you do have a GPU and don't set TF_GPU to ```true```, then the ```tensorflow``` cpu-only dependency is
   assumed and deconvolution will not use GPU acceleration (so make sure to set this variable). 
-
 
 ### Docker Instructions
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,5 @@
 FROM tensorflow/tensorflow:1.6.0-py3
 
-ENV TF_GPU false
-
 RUN apt-get update && apt-get install -y --no-install-recommends git vim
 
 RUN mkdir /repos && cd /repos && \

--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -1,7 +1,5 @@
 FROM tensorflow/tensorflow:1.6.0-py3
 
-ENV TF_GPU false
-
 RUN apt-get update && apt-get install -y --no-install-recommends git vim
 
 RUN mkdir -p /repos/flowdec

--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -1,7 +1,5 @@
 FROM tensorflow/tensorflow:1.6.0-py3-gpu
 
-ENV TF_GPU true
-
 RUN apt-get update && apt-get install -y --no-install-recommends git vim
 
 RUN mkdir /repos && cd /repos && \

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
 scikit-image
 matplotlib
 requests
-# TensorFlow CPUvsGPU dependency to be determined at runtime
+# `tensorflow` or `tensorflow-gpu` must be installed, as well.

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,17 +1,12 @@
 from setuptools import setup
 import os
 
-if os.getenv('TF_GPU', 'false') == 'true':
-    requires = ['tensorflow-gpu>=1.6.0']
-else:
-    requires = ['tensorflow>=1.6.0']
-
 try:
     with open('requirements.txt', 'r') as fd:
-        requires += [l.strip() for l in fd.readlines()]
+        requires = [l.strip() for l in fd.readlines()]
 except FileNotFoundError:
     # for when running in a tox virtualenv
-    requires += ['scikit-image', 'matplotlib', 'requests']
+    requires = ['scikit-image', 'matplotlib', 'requests']
 
 if __name__ == '__main__':
     setup(
@@ -31,6 +26,10 @@ if __name__ == '__main__':
             'Programming Language :: Python :: 3.6'
         ],
         install_requires=requires,
+        extras_require={
+            "tf": ["tensorflow>=1.6.0"],
+            "tf_gpu": ["tensorflow-gpu>=1.6.0"],
+        },
         packages=['flowdec', 'flowdec.cmd', 'flowdec.nb'],
         package_data={'flowdec': ['datasets/*/*.tif']},
         entry_points={

--- a/python/test-requirements.txt
+++ b/python/test-requirements.txt
@@ -1,1 +1,2 @@
 flake8
+nose

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -4,6 +4,7 @@ envlist = flake8,smoke,tests
 [testenv]
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
+       tensorflow
 
 [testenv:smoke]
 commands = {toxinidir}/tests/smoketest.sh
@@ -46,7 +47,6 @@ commands = flake8 --ignore=E501,E124,E125,E126,E127,E128,E131,E201,E202,E203,E22
                   {toxinidir}/examples/scripts
 
 [testenv:tests]
-deps = nose
 commands = nosetests []
 
 [flake8]


### PR DESCRIPTION
Issue #10 is a case where installing flowdec automatically installed
tensorflow even though tensorflow-gpu was already installed.  To avoid
any accidental install errors, we can just document the tensorflow
requirement and have each environment ensure they install the
tensorflow version they need as a prerequisite.