### PR TITLE
Python updates for recent changes in tensorflow and dependent libs

### DIFF
--- a/python/flowdec/fft_utils_np.py
+++ b/python/flowdec/fft_utils_np.py
@@ -16,7 +16,7 @@ def _rainbow_next_largest(n):
 
 def optimize_dims(dims, mode):
     """Computes FFT Length for data padded out to optimize FFT implementations"""
-    from scipy import fftpack
+    from scipy import fft
     mode = mode.upper()
 
     # Round FFT Length up to next nearest optimal value based on mode given
@@ -25,7 +25,7 @@ def optimize_dims(dims, mode):
     elif mode == OPM_2357:
         return np.array([_rainbow_next_largest(d) for d in dims])
     elif mode == OPM_FFTP:
-        return np.array([fftpack.helper.next_fast_len(int(sz)) for sz in dims])
+        return np.array([fft.next_fast_len(int(sz)) for sz in dims])
     elif mode != OPM_NONE:
         raise ValueError('Padding mode "{}" invalid'.format(mode))
     return dims

--- a/python/flowdec/fft_utils_np.py
+++ b/python/flowdec/fft_utils_np.py
@@ -16,7 +16,7 @@ def _rainbow_next_largest(n):
 
 def optimize_dims(dims, mode):
     """Computes FFT Length for data padded out to optimize FFT implementations"""
-    from scipy.signal.signaltools import fftpack
+    from scipy import fftpack
     mode = mode.upper()
 
     # Round FFT Length up to next nearest optimal value based on mode given
@@ -50,10 +50,3 @@ def extract(data, base_dims, pad_dims):
     pad_slice_optim = tuple([slice(0, int(sz)) for sz in pad_dims])
 
     return data[pad_slice_optim][pad_slice]
-
-
-
-
-
-
-

--- a/python/flowdec/fft_utils_test.py
+++ b/python/flowdec/fft_utils_test.py
@@ -114,9 +114,9 @@ class TestFFTUtils(unittest.TestCase):
         np_res = fft_utils_np.convolve(d, k)
 
         assert_almost_equal(tf_res, np_res, decimal=3)
-        self.assertEquals(tf_res.shape, np_res.shape)
+        self.assertEqual(tf_res.shape, np_res.shape)
         if actual is not None:
-            assert_array_equal(tf_res, actual)
+            assert_almost_equal(tf_res, actual, decimal=6)
 
     def test_convolution(self):
 

--- a/python/flowdec/test_utils.py
+++ b/python/flowdec/test_utils.py
@@ -6,5 +6,5 @@ def exec_tf(fn):
     g = tf.Graph()
     with g.as_default():
         tf_res = fn()
-    with tf.Session(graph=g) as sess:
+    with tf.compat.v1.Session(graph=g) as sess:
         return sess.run(tf_res)

--- a/python/flowdec/tf_ops.py
+++ b/python/flowdec/tf_ops.py
@@ -16,7 +16,7 @@ def tf_print(t, transform=None):
 
 def tf_observer(tensors, observer_fn):
     """Inject graph operation to observe but not alter tensor values
-    
+
     Args:
         t: List of tensors to send to observer
         observer_fn: Function with signature ```fn(tensors)``` where tensors will be a list
@@ -28,7 +28,7 @@ def tf_observer(tensors, observer_fn):
     def _observe(*args):
         observer_fn(*args)
         return np.array([0], dtype=np.int32)
-    observe_op = tf.py_func(_observe, tensors, tf.int32, stateful=True, name='observer')[0]
+    observe_op = tf.numpy_function(_observe, tensors, tf.int32, name='observer')[0]
     with tf.control_dependencies([observe_op]):
         ts = [tf.identity(t) for t in tensors]
     return ts

--- a/python/flowdec/validation.py
+++ b/python/flowdec/validation.py
@@ -5,7 +5,7 @@ from flowdec import exec as fd_exec
 from flowdec.fft_utils_tf import OPTIMAL_PAD_MODES, OPM_LOG2
 from skimage.transform import resize
 from scipy.ndimage.interpolation import shift as scipy_shift
-from skimage.measure import compare_ssim
+from skimage.metrics import structural_similarity
 from scipy.signal import fftconvolve
 import numpy as np
 
@@ -30,8 +30,8 @@ def shift(acq, data_shift=None, kern_shift=None):
 def subset(acq, data_slice=None, kern_slice=None):
     """Apply slice operation to acquisition data"""
     return mutate(acq,
-        data_fn=None if not data_slice else lambda d: d[data_slice],
-        kern_fn=None if not kern_slice else lambda k: k[kern_slice]
+        data_fn=None if not data_slice else lambda d: d[tuple(data_slice)],
+        kern_fn=None if not kern_slice else lambda k: k[tuple(kern_slice)]
     )
 
 
@@ -63,7 +63,7 @@ def binarize(img):
 
 def score(img_pred, img_true):
     """Convert similarity score between images to validate"""
-    return compare_ssim(img_pred, img_true, data_range=img_true.max() - img_true.min())
+    return structural_similarity(img_pred, img_true, data_range=img_true.max() - img_true.min())
 
 
 def reblur(acq, scale=.05, seed=1):


### PR DESCRIPTION
Almost all changes are renames.  Some of the renames for TF
use V1 compatibility API, which means eager evaluation will
not work (I believe).

This will break those using older TF, scipy, skimage versions.

Tested in TF 1.14, 1.15, and 2.0, with and without GPU:
python/flowdec/*_test.py all pass
python/tests/smoketests.sh runs
